### PR TITLE
feat(SOURCE): add support for compile flag

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -51,21 +51,27 @@ function exec(options, callback) {
         return process.nextTick(function() { callback(new Error('ERROR_NO_OUTPUT')); });
     }
 
-    if(!options.resource) {
+    if(options.operation !== 'compile' && !options.resource) {
         return process.nextTick(function() { callback(new Error('ERROR_NO_RESOURCE')); });
     }
 
-    if(!options.resourceType) {
+    if(options.operation !== 'compile' && !options.resourceType) {
         return process.nextTick(function() { callback(new Error('ERROR_NO_RESOURCE_TYPE')); });
     }
 
-    if(!options.resourceName) {
+    if(options.operation !== 'compile' && !options.resourceName) {
         return process.nextTick(function() { callback(new Error('ERROR_NO_RESOURCE_NAME')); });
     }
 
     var args = [PATH_RESOURCE_HACKER_EXE];
 
     switch(options.operation) {
+    case 'compile':
+        args.push('-action compile',
+            util.format('-open %s,', normalize(options.input)),
+            util.format('-save %s,', normalize(options.output))
+        );
+        break;
     case 'add':
         args.push('-add',
             util.format('%s,', normalize(options.input)),


### PR DESCRIPTION
New API function: `operation: 'compile'`
```javascript
resourcehacker({
  operation: 'compile',
  input: 'version-info.rc',
  output: 'version-info.res'
}, (err) => {
  if (err) return console.log(err)
  console.log('Done compiling VERSIONINFO.')
})
```